### PR TITLE
Port random fuzzing parameters to AFLplusplus

### DIFF
--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -149,10 +149,6 @@ struct tainted {
 
 };
 
-struct potential_favored_input {
-  struct queue_entry *queue;
-  struct potential_favored_input *next;
-};
 struct queue_entry {
 
   u8 *fname;                            /* File name for the test case      */
@@ -198,7 +194,7 @@ struct queue_entry {
   u8 *            cmplog_colorinput;    /* the result buf of colorization   */
   struct tainted *taint;                /* Taint information from CmpLog    */
 
-  struct queue_entry *mother;           /* queue entry this based on        */  
+  struct queue_entry *mother;           /* queue entry this based on        */
 
 };
 
@@ -209,8 +205,6 @@ struct extra_data {
   u32 hit_cnt;                          /* Use count in the corpus          */
 
 };
-
-
 
 struct auto_extra_data {
 
@@ -645,7 +639,7 @@ typedef struct afl_state {
   struct extra_data *extras;            /* Extra tokens to fuzz with        */
   u32                extras_cnt;        /* Total number of tokens read      */
 
-  struct potential_favored_input* potential_favored_list[MAP_SIZE];
+  struct queue_entry* edge_to_minimum_entry[MAP_SIZE];
 
   struct auto_extra_data
       a_extras[MAX_AUTO_EXTRAS];        /* Automatically selected extras    */
@@ -786,8 +780,6 @@ typedef struct afl_state {
 #endif
 
 } afl_state_t;
-
-
 
 struct custom_mutator {
 

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -639,8 +639,6 @@ typedef struct afl_state {
   struct extra_data *extras;            /* Extra tokens to fuzz with        */
   u32                extras_cnt;        /* Total number of tokens read      */
 
-  struct queue_entry* edge_to_minimum_entry[MAP_SIZE];
-
   struct auto_extra_data
       a_extras[MAX_AUTO_EXTRAS];        /* Automatically selected extras    */
   u32 a_extras_cnt;                     /* Total number of tokens available */

--- a/include/afl-fuzz.h
+++ b/include/afl-fuzz.h
@@ -1137,6 +1137,8 @@ u8   pilot_fuzzing(afl_state_t *);
 u8   core_fuzzing(afl_state_t *);
 void pso_updating(afl_state_t *);
 u8   fuzz_one(afl_state_t *);
+void reset_fuzzing_params(afl_state_t * afl);
+void randomize_fuzzing_params(afl_state_t * afl);
 
 /* Init */
 

--- a/src/afl-fuzz-one.c
+++ b/src/afl-fuzz-one.c
@@ -2881,7 +2881,7 @@ abandon_entry:
 
 }
 
-static void reset_fuzzing_params(afl_state_t * afl) {
+void reset_fuzzing_params(afl_state_t * afl) {
   afl->custom_havoc_cycles       = HAVOC_CYCLES;
   afl->custom_havoc_stack_pow2   = HAVOC_STACK_POW2;
   afl->custom_havoc_blk_small    = HAVOC_BLK_SMALL;
@@ -2891,7 +2891,7 @@ static void reset_fuzzing_params(afl_state_t * afl) {
   afl->custom_splice_havoc       = SPLICE_HAVOC;
 }
 
-static void randomize_fuzzing_params(afl_state_t * afl) {
+void randomize_fuzzing_params(afl_state_t * afl) {
   afl->custom_havoc_cycles       = rand_int_in_range(afl, 192, 320);
   afl->custom_havoc_stack_pow2   = rand_int_in_range(afl, 4, 10);
   afl->custom_havoc_blk_small    = rand_int_in_range(afl, 24, 40);

--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -736,7 +736,7 @@ void cull_queue(afl_state_t *afl) {
         // enable_boost_fast_seqs
         double base_weight_fac_boost_fast = 8.0;
         double max_weight_fac_decr = 7.0;
-        double scale_fac_boost_fast = 0.005;
+        double scale_fac_boost_fast = 0.001; // based on the past experiment, 0.001 seems to be the best candidate among 0.005, 0.0025, 0.0005
         double execs_per_sec = 1000000.0 / (double)afl->queue_buf[i]->exec_us;
         weight *= base_weight_fac_boost_fast - max_weight_fac_decr / (scale_fac_boost_fast*execs_per_sec + 1.0);
       }

--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -600,7 +600,7 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
 
         if (!--afl->top_rated[i]->tc_ref) {
           
-          // don't free it for now, need to usse this mini map to determine favored inputs later
+          // don't free it for now, need to use this mini map to determine favored inputs later
           // ck_free(afl->top_rated[i]->trace_mini);
           // afl->top_rated[i]->trace_mini = 0;
 

--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -439,6 +439,7 @@ void add_to_queue(afl_state_t *afl, u8 *fname, u32 len, u8 passed_det) {
   q->trace_mini = NULL;
   q->testcase_buf = NULL;
   q->mother = afl->queue_cur;
+  q->num_fuzzed   = 0;
 
 #ifdef INTROSPECTION
   q->bitsmap_size = afl->bitsmap_size;
@@ -523,6 +524,23 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
   u32 i;
   u64 fav_factor;
   u64 fuzz_p2;
+
+  // this overides how afl tracks score for favorite input selection
+  if (!afl->disable_random_favorites) {
+    for (i = 0; i < MAP_SIZE; i++) {
+      if (afl->fsrv.trace_bits[i]) {
+
+      // insert a new element of input into a linked list for current edge id
+      struct potential_favored_input* new_potential = ck_alloc(sizeof(struct potential_favored_input));
+      new_potential->queue = q;
+      new_potential->next = afl->potential_favored_list[i];
+
+      afl->potential_favored_list[i] = new_potential;
+      afl->score_changed = 1;
+      }
+    }
+    return;
+  }
 
   if (unlikely(afl->schedule >= FAST && afl->schedule < RARE))
     fuzz_p2 = 0;  // Skip the fuzz_p2 comparison
@@ -648,47 +666,120 @@ void cull_queue(afl_state_t *afl) {
   afl->queued_favored = 0;
   afl->pending_favored = 0;
 
-  for (i = 0; i < afl->queued_paths; i++) {
+    // use AFL's original mechanism to assign favorites
+  if (afl->disable_random_favorites) {
 
-    afl->queue_buf[i]->favored = 0;
+    for (i = 0; i < afl->queued_paths; i++) {
 
-  }
+      if (afl->disable_afl_default_favorites) {
+          afl->queue_buf[i]->favored = 1;
+        } else{
+          afl->queue_buf[i]->favored = 0;
+        }
 
-  /* Let's see if anything in the bitmap isn't captured in temp_v.
-     If yes, and if it has a afl->top_rated[] contender, let's use it. */
+    }
 
-  for (i = 0; i < afl->fsrv.map_size; ++i) {
+    /* Let's see if anything in the bitmap isn't captured in temp_v.
+      If yes, and if it has a afl->top_rated[] contender, let's use it. */
 
-    if (afl->top_rated[i] && (temp_v[i >> 3] & (1 << (i & 7)))) {
+    for (i = 0; i < afl->fsrv.map_size; ++i) {
 
-      u32 j = len;
+      if (afl->top_rated[i] && (temp_v[i >> 3] & (1 << (i & 7)))) {
 
-      /* Remove all bits belonging to the current entry from temp_v. */
+        u32 j = len;
 
-      while (j--) {
+        /* Remove all bits belonging to the current entry from temp_v. */
 
-        if (afl->top_rated[i]->trace_mini[j]) {
+        while (j--) {
 
-          temp_v[j] &= ~afl->top_rated[i]->trace_mini[j];
+          if (afl->top_rated[i]->trace_mini[j]) {
+
+            temp_v[j] &= ~afl->top_rated[i]->trace_mini[j];
+
+          }
+
+        }
+
+        if (!afl->top_rated[i]->favored) {
+
+          afl->top_rated[i]->favored = 1;
+          ++afl->queued_favored;
+
+          if (afl->top_rated[i]->fuzz_level == 0 ||
+              !afl->top_rated[i]->was_fuzzed) {
+
+            ++afl->pending_favored;
+
+          }
 
         }
 
       }
 
-      if (!afl->top_rated[i]->favored) {
+    }
+  } else {
+    // otherwise, randomly assign favorites
+    int r;
+    int rid;
+    double weight;
 
-        afl->top_rated[i]->favored = 1;
-        ++afl->queued_favored;
+    for (i = 0; i < afl->queued_paths; i++) {
+      weight = 1.0;
+      if (!afl->enable_uniformly_random_favorites) {
+        // enable_boost_inputs
+        double base_weight_fac_boost_inputs = 1.0;
+        double max_weight_fac_incr = 7.0;
+        double scale_fac_boost_inputs = 0.001;
+        double num_selections = (double)afl->queue_buf[i]->num_fuzzed;
+        weight *= base_weight_fac_boost_inputs + max_weight_fac_incr / (scale_fac_boost_inputs * num_selections + 1.0);
 
-        if (afl->top_rated[i]->fuzz_level == 0 ||
-            !afl->top_rated[i]->was_fuzzed) {
-
-          ++afl->pending_favored;
-
-        }
-
+        // enable_boost_fast_seqs
+        double base_weight_fac_boost_fast = 8.0;
+        double max_weight_fac_decr = 7.0;
+        double scale_fac_boost_fast = 0.005;
+        double execs_per_sec = 1000000.0 / (double)afl->queue_buf[i]->exec_us;
+        weight *= base_weight_fac_boost_fast - max_weight_fac_decr / (scale_fac_boost_fast*execs_per_sec + 1.0);
+      }
+      r = 0;
+      rid = INT_MAX;
+      while (weight >= 1.0) {
+        r = rand_below(afl, INT_MAX);
+        if (r < rid)
+          rid = r;
+        weight -= 1.0;
+      }
+      if (weight > 0.0 && weight > rand_double(afl)) {
+        r = rand_below(afl, INT_MAX);
+        if (r < rid)
+          rid = r;
       }
 
+      afl->queue_buf[i]->favored = 0;
+      afl->queue_buf[i]->rand = rid;
+    }
+
+    for (i = 0; i < MAP_SIZE; i++) {
+      if (afl->potential_favored_list[i]) {
+        struct potential_favored_input* potential_input = afl->potential_favored_list[i];
+        struct queue_entry* new_top_rated;
+        int minimum_random_number = INT_MAX;
+
+        while (potential_input) {
+          // if the random is the new minimum, the seed is favored
+          if (potential_input->queue->rand < minimum_random_number) {
+            minimum_random_number = potential_input->queue->rand;
+            new_top_rated = potential_input->queue;
+          }
+          potential_input = potential_input->next;
+        }
+
+        if (new_top_rated && !new_top_rated->favored) {
+          new_top_rated->favored = 1;
+          afl->queued_favored++;
+          if (!new_top_rated->was_fuzzed)
+            afl->pending_favored++;
+        }
+      }
     }
 
   }

--- a/src/afl-fuzz-queue.c
+++ b/src/afl-fuzz-queue.c
@@ -599,9 +599,10 @@ void update_bitmap_score(afl_state_t *afl, struct queue_entry *q) {
            previous winner, discard its afl->fsrv.trace_bits[] if necessary. */
 
         if (!--afl->top_rated[i]->tc_ref) {
-
-          ck_free(afl->top_rated[i]->trace_mini);
-          afl->top_rated[i]->trace_mini = 0;
+          
+          // don't free it for now, need to usse this mini map to determine favored inputs later
+          // ck_free(afl->top_rated[i]->trace_mini);
+          // afl->top_rated[i]->trace_mini = 0;
 
         }
 

--- a/src/afl-fuzz-run.c
+++ b/src/afl-fuzz-run.c
@@ -921,6 +921,8 @@ common_fuzz_stuff(afl_state_t *afl, u8 *out_buf, u32 len) {
 
   fault = fuzz_run_target(afl, &afl->fsrv, afl->fsrv.exec_tmout);
 
+  afl->queue_cur->num_fuzzed++;
+
   if (afl->stop_soon) { return 1; }
 
   if (fault == FSRV_RUN_TMOUT) {

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1354,13 +1354,7 @@ int main(int argc, char **argv_orig, char **envp) {
 
   // initialize with default values if we don't want to radomize ruzzing params
   if (afl->disable_randomized_fuzzing_params) {
-    afl->custom_havoc_cycles       = HAVOC_CYCLES;
-    afl->custom_havoc_stack_pow2   = HAVOC_STACK_POW2;
-    afl->custom_havoc_blk_small    = HAVOC_BLK_SMALL;
-    afl->custom_havok_blk_medium   = HAVOC_BLK_MEDIUM;
-    afl->custom_havoc_blk_large    = HAVOC_BLK_LARGE;
-    afl->custom_splice_cycles      = SPLICE_CYCLES;
-    afl->custom_splice_havoc       = SPLICE_HAVOC;
+    reset_fuzzing_params(afl);
   }
 
   if (getenv("AFL_RP_PROB")) {

--- a/src/afl-fuzz.c
+++ b/src/afl-fuzz.c
@@ -1352,6 +1352,17 @@ int main(int argc, char **argv_orig, char **envp) {
   if (getenv("AFL_DISABLE_FAVS"))     afl->disable_afl_default_favorites       = 1;
   if (getenv("AFL_DISABLE_RP"))       afl->disable_randomized_fuzzing_params   = 1;
 
+  // initialize with default values if we don't want to radomize ruzzing params
+  if (afl->disable_randomized_fuzzing_params) {
+    afl->custom_havoc_cycles       = HAVOC_CYCLES;
+    afl->custom_havoc_stack_pow2   = HAVOC_STACK_POW2;
+    afl->custom_havoc_blk_small    = HAVOC_BLK_SMALL;
+    afl->custom_havok_blk_medium   = HAVOC_BLK_MEDIUM;
+    afl->custom_havoc_blk_large    = HAVOC_BLK_LARGE;
+    afl->custom_splice_cycles      = SPLICE_CYCLES;
+    afl->custom_splice_havoc       = SPLICE_HAVOC;
+  }
+
   if (getenv("AFL_RP_PROB")) {
     afl->randomize_parameters_prob = strtoul(getenv("AFL_RP_PROB"), 0L, 10);
   } 


### PR DESCRIPTION
This PR ports the idea of randomizing fuzzing parameters (i.e. random weight selection, uniformly random selection, etc.) implemented in https://github.com/Practical-Formal-Methods/AFL-public/pull/6 to afl++.